### PR TITLE
Increase number of materials, per-face materials, fixups for 4.7

### DIFF
--- a/Plugins/BrickGrid/Source/BrickGrid/Classes/BrickGridComponent.h
+++ b/Plugins/BrickGrid/Source/BrickGrid/Classes/BrickGridComponent.h
@@ -6,7 +6,7 @@
 namespace BrickGridConstants
 {
 	enum { MaxBricksPerRegionAxisLog2 = 7 };
-	enum { MaxBricksPerRegionAxis = 1 << MaxBricksPerRegionAxisLog2 };
+	enum { MaxBricksPerRegionAxis = 1 << MaxBricksPerRegionAxisLog2 };   
 };
 
 /** Shifts a number right with sign extension. */
@@ -26,19 +26,27 @@ inline int32 SignedShiftRight(int32 A,int32 B)
 	#endif
 }
 
+UENUM(BlueprintType)
+enum class EBrickFace : uint8
+{
+    BF_PlusZ UMETA(DisplayName = "PlusZ"),
+    BF_MinusZ UMETA(DisplayName = "MinusZ"),
+    BF_PlusX UMETA(DisplayName = "PlusX"),
+    BF_MinusX UMETA(DisplayName = "MinusX"),
+    BF_PlusY UMETA(DisplayName = "PlusY"),
+    BF_MinusY UMETA(DisplayName = "MinusY")
+};
+
 /** Information about a brick material. */
 USTRUCT(BlueprintType)
 struct FBrickMaterial
 {
-	GENERATED_USTRUCT_BODY()
+    GENERATED_USTRUCT_BODY()
 
-	UPROPERTY(EditAnywhere,BlueprintReadWrite,Category = Bricks)
-	class UMaterialInterface* SurfaceMaterial;
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bricks)
+    TArray<class UMaterialInterface*> FaceMaterials;
 
-	UPROPERTY(EditAnywhere,BlueprintReadWrite,Category = Bricks)
-	class UMaterialInterface* OverrideTopSurfaceMaterial;
-
-	FBrickMaterial() : SurfaceMaterial(NULL), OverrideTopSurfaceMaterial(NULL) {}
+    FBrickMaterial() {}
 };
 
 /** Information about a brick. */
@@ -157,7 +165,7 @@ struct FBrickRegion
 
 	// Contains the material index for each brick, stored in an 8-bit integer.
 	UPROPERTY()
-	TArray<uint8> BrickContents;
+    TArray<uint16> BrickContents;
 
 	// Contains the occupied brick with highest Z in this region for each XY coordinate in the region. -1 means no non-empty bricks in this region at that XY.
 	TArray<int8> MaxNonEmptyBrickRegionZs;
@@ -170,11 +178,11 @@ struct FBrickGridParameters
 	GENERATED_USTRUCT_BODY()
 
 	// The materials to render for each brick material.
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Materials)
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = Materials)
 	TArray<FBrickMaterial> Materials;
 
 	// The material index that means "empty".
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Materials)
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = Materials)
 	int32 EmptyMaterialIndex;
 
 	// The number of bricks along each axis of a region is 2^BricksPerChunkLog2
@@ -242,8 +250,8 @@ public:
 	UFUNCTION(BlueprintCallable,Category = "Brick Grid")
 	BRICKGRID_API FBrick GetBrick(const FInt3& BrickCoordinates) const;
 
-	BRICKGRID_API void GetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,TArray<uint8>& OutBrickMaterials) const;
-	BRICKGRID_API void SetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,const TArray<uint8>& BrickMaterials);
+	BRICKGRID_API void GetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,TArray<uint16>& OutBrickMaterials) const;
+	BRICKGRID_API void SetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,const TArray<uint16>& BrickMaterials);
 
 	// Returns a height-map containing the non-empty brick with greatest Z for each XY in the rectangle bounded by MinBrickCoordinates.XY-MaxBrickCoordinates.XY.
 	// The returned heights are relative to MinBrickCoordinates.Z, but MaxBrickCoordinates.Z is ignored.

--- a/Plugins/BrickGrid/Source/BrickGrid/Private/BrickAmbientOcclusion.inl
+++ b/Plugins/BrickGrid/Source/BrickGrid/Private/BrickAmbientOcclusion.inl
@@ -6,7 +6,7 @@ static void ComputeChunkAO(
 	const FInt3 LocalBrickExpansion,
 	const FInt3 LocalBricksDim,
 	const FInt3 LocalVertexDim,
-	const TArray<uint8>& LocalBrickMaterials,
+	const TArray<uint16>& LocalBrickMaterials,
 	TArray<uint8>& OutLocalVertexAmbientFactors
 	)
 {

--- a/Plugins/BrickGrid/Source/BrickGrid/Private/BrickCollisionComponent.cpp
+++ b/Plugins/BrickGrid/Source/BrickGrid/Private/BrickCollisionComponent.cpp
@@ -15,7 +15,7 @@ static const FInt3 FaceNormals[6] =
 	FInt3(0, 0, +1)
 };
 
-UBrickCollisionComponent::UBrickCollisionComponent( const FPostConstructInitializeProperties& PCIP )
+UBrickCollisionComponent::UBrickCollisionComponent(const FObjectInitializer& PCIP)
 	: Super( PCIP )
 {
 	PrimaryComponentTick.bCanEverTick = false;
@@ -65,7 +65,7 @@ void UBrickCollisionComponent::UpdateCollisionBody()
 
 	// Read the brick materials for all the bricks that affect this chunk.
 	const FInt3 LocalBricksDim = Grid->BricksPerCollisionChunk + LocalBrickExpansion * FInt3::Scalar(2);
-	TArray<uint8> LocalBrickMaterials;
+	TArray<uint16> LocalBrickMaterials;
 	LocalBrickMaterials.Init(LocalBricksDim.X * LocalBricksDim.Y * LocalBricksDim.Z);
 	Grid->GetBrickMaterialArray(MinLocalBrickCoordinates,MinLocalBrickCoordinates + LocalBricksDim - FInt3::Scalar(1),LocalBrickMaterials);
 

--- a/Plugins/BrickGrid/Source/BrickGrid/Private/BrickGridComponent.cpp
+++ b/Plugins/BrickGrid/Source/BrickGrid/Private/BrickGridComponent.cpp
@@ -95,7 +95,7 @@ FBrick UBrickGridComponent::GetBrick(const FInt3& BrickCoordinates) const
 	return FBrick(Parameters.EmptyMaterialIndex);
 }
 
-void UBrickGridComponent::GetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,TArray<uint8>& OutBrickMaterials) const
+void UBrickGridComponent::GetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,TArray<uint16>& OutBrickMaterials) const
 {
 	const FInt3 OutputSize = MaxBrickCoordinates - MinBrickCoordinates + FInt3::Scalar(1);
 	const FInt3 MinRegionCoordinates = BrickToRegionCoordinates(MinBrickCoordinates);
@@ -123,11 +123,11 @@ void UBrickGridComponent::GetBrickMaterialArray(const FInt3& MinBrickCoordinates
 						const uint32 RegionBaseBrickIndex = (((RegionBrickY << Parameters.BricksPerRegionLog2.X) + RegionBrickX) << Parameters.BricksPerRegionLog2.Z) + MinOutputRegionBrickCoordinates.Z;
 						if(RegionIndex)
 						{
-							FMemory::Memcpy(&OutBrickMaterials[OutputBaseBrickIndex],&Regions[*RegionIndex].BrickContents[RegionBaseBrickIndex],OutputSizeZ * sizeof(uint8));
+                            FMemory::Memcpy(&OutBrickMaterials[OutputBaseBrickIndex], &Regions[*RegionIndex].BrickContents[RegionBaseBrickIndex], OutputSizeZ * sizeof(OutBrickMaterials[0]));
 						}
 						else
 						{
-							FMemory::Memset(&OutBrickMaterials[OutputBaseBrickIndex],Parameters.EmptyMaterialIndex,OutputSizeZ * sizeof(uint8));
+                            FMemory::Memset(&OutBrickMaterials[OutputBaseBrickIndex], Parameters.EmptyMaterialIndex, OutputSizeZ * sizeof(OutBrickMaterials[0]));
 						}
 					}
 				}
@@ -136,7 +136,7 @@ void UBrickGridComponent::GetBrickMaterialArray(const FInt3& MinBrickCoordinates
 	}
 }
 
-void UBrickGridComponent::SetBrickMaterialArray(const FInt3& MinBrickCoordinates,const FInt3& MaxBrickCoordinates,const TArray<uint8>& BrickMaterials)
+void UBrickGridComponent::SetBrickMaterialArray(const FInt3& MinBrickCoordinates, const FInt3& MaxBrickCoordinates, const TArray<uint16>& BrickMaterials)
 {
 	const FInt3 InputSize = MaxBrickCoordinates - MinBrickCoordinates + FInt3::Scalar(1);
 	const FInt3 MinRegionCoordinates = BrickToRegionCoordinates(MinBrickCoordinates);
@@ -164,7 +164,7 @@ void UBrickGridComponent::SetBrickMaterialArray(const FInt3& MinBrickCoordinates
 						const uint32 RegionBaseBrickIndex = (((RegionBrickY << Parameters.BricksPerRegionLog2.X) + RegionBrickX) << Parameters.BricksPerRegionLog2.Z) + MinInputRegionBrickCoordinates.Z;
 						if(RegionIndex)
 						{
-							FMemory::Memcpy(&Regions[*RegionIndex].BrickContents[RegionBaseBrickIndex],&BrickMaterials[InputBaseBrickIndex],InputSizeZ * sizeof(uint8));
+                            FMemory::Memcpy(&Regions[*RegionIndex].BrickContents[RegionBaseBrickIndex], &BrickMaterials[InputBaseBrickIndex], InputSizeZ * sizeof(BrickMaterials[0]));
 						}
 					}
 				}
@@ -519,7 +519,7 @@ FBrickGridParameters::FBrickGridParameters()
 	Materials.Add(FBrickMaterial());
 }
 
-UBrickGridComponent::UBrickGridComponent(const FPostConstructInitializeProperties& PCIP)
+UBrickGridComponent::UBrickGridComponent(const FObjectInitializer& PCIP)
 : Super( PCIP )
 {
 	PrimaryComponentTick.bStartWithTickEnabled =true;


### PR DESCRIPTION
Change material array index type to uint16 to allow more materials.
Allow individual materials per-face.
Minor fixups for compilation warnings/errors for 4.7.
NOTE: To actually use per-face materials requires a shader which can
synthesize correct UV coordinates for the vertical faces - by default
the UV coordinates are mapped to the XY vertex coordinates.