### PR TITLE
Compressed Saving and Loading (ZLIB)

### DIFF
--- a/Plugins/BrickGrid/Source/BrickGrid/Classes/BrickGridComponent.h
+++ b/Plugins/BrickGrid/Source/BrickGrid/Classes/BrickGridComponent.h
@@ -103,6 +103,13 @@ struct FInt3
 	{
 		return A.X == B.X && A.Y == B.Y && A.Z == B.Z;
 	}
+	friend FArchive& operator<<(FArchive& Ar, FInt3& other)
+	{
+		Ar << other.X;
+		Ar << other.Y;
+		Ar << other.Z;
+		return Ar;
+	}
 	static inline FInt3 SignedShiftRight(const FInt3& A,const FInt3& B)
 	{
 		return FInt3(::SignedShiftRight(A.X,B.X),::SignedShiftRight(A.Y,B.Y),::SignedShiftRight(A.Z,B.Z));
@@ -215,6 +222,24 @@ struct FBrickGridData
 	TArray<struct FBrickRegion> Regions;
 };
 
+//Overload << for FBrickRegion
+FORCEINLINE FArchive& operator<<(FArchive& Ar, FBrickRegion& data)
+{
+	Ar << data.BrickContents; //TArray<uint8>
+	Ar << data.Coordinates; //Fint3
+	Ar << data.MaxNonEmptyBrickRegionZs; //TArray<int8>
+
+	return Ar;
+}
+
+//Overload << for FBrickGridData
+FORCEINLINE FArchive& operator<<(FArchive& Ar, FBrickGridData& data)
+{
+	Ar << data.Regions;
+
+	return Ar;
+}
+
 // The type of OnInitRegion delegates.
 DECLARE_DYNAMIC_DELEGATE_OneParam(FBrickGrid_InitRegion,FInt3,RegionCoordinates);
 
@@ -261,6 +286,14 @@ public:
 	// Updates the visible chunks for a given view position.
 	UFUNCTION(BlueprintCallable,Category = "Brick Grid")
 	void Update(const FVector& WorldViewPosition,float MaxDrawDistance,float MaxCollisionDistance,float MaxDesiredUpdateTime,FBrickGrid_InitRegion InitRegion);
+
+	// Saves the current brick grid into an zlib compressed file
+	UFUNCTION(BlueprintCallable, Category = "Brick Grid")
+	bool SaveCompressed(FString path);
+
+	// Loads a saved brick grid into the current component
+	UFUNCTION(BlueprintCallable, Category = "Brick Grid")
+	bool LoadCompressed(FString path);
 
 	// The parameters for the grid.
 	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category = "Brick Grid")

--- a/Plugins/BrickGrid/Source/BrickGrid/Private/BrickGridComponent.cpp
+++ b/Plugins/BrickGrid/Source/BrickGrid/Private/BrickGridComponent.cpp
@@ -508,7 +508,7 @@ bool UBrickGridComponent::SaveCompressed(FString path)
 	toBeSaved.Regions = Regions;
 	bufArchive << toBeSaved;
 
-	UE_LOG(LogStats, Log, TEXT("Precompiled File Size: %s"), *FString::FromInt(bufArchive.Num()));
+	UE_LOG(LogStats, Log, TEXT("Precompressed File Size: %s"), *FString::FromInt(bufArchive.Num()));
 
 	TArray<uint8> compressedData;
 	FArchiveSaveCompressedProxy proxy = FArchiveSaveCompressedProxy(compressedData, COMPRESS_ZLIB);

--- a/Plugins/BrickGrid/Source/BrickGrid/Private/BrickGridComponent.cpp
+++ b/Plugins/BrickGrid/Source/BrickGrid/Private/BrickGridComponent.cpp
@@ -500,6 +500,81 @@ void UBrickGridComponent::Update(const FVector& WorldViewPosition,float MaxDrawD
 	}
 }
 
+bool UBrickGridComponent::SaveCompressed(FString path)
+{
+	FBufferArchive bufArchive;
+
+	FBrickGridData toBeSaved;
+	toBeSaved.Regions = Regions;
+	bufArchive << toBeSaved;
+
+	UE_LOG(LogStats, Log, TEXT("Precompiled File Size: %s"), *FString::FromInt(bufArchive.Num()));
+
+	TArray<uint8> compressedData;
+	FArchiveSaveCompressedProxy proxy = FArchiveSaveCompressedProxy(compressedData, COMPRESS_ZLIB);
+
+	proxy << bufArchive;
+
+	proxy.Flush();
+
+	UE_LOG(LogStats, Log, TEXT("Compressed File Size: %s"), *FString::FromInt(compressedData.Num()));
+
+	bool saveResult = FFileHelper::SaveArrayToFile(compressedData, *path);
+
+	proxy.FlushCache();
+	compressedData.Empty();
+
+	bufArchive.FlushCache();
+	bufArchive.Empty();
+
+	if (saveResult)
+		bufArchive.Close();
+
+	return saveResult;
+}
+
+bool UBrickGridComponent::LoadCompressed(FString path)
+{
+	if (!FPaths::FileExists(path))
+		return false;
+
+	TArray<uint8> compressedData;
+	if (!FFileHelper::LoadFileToArray(compressedData, *path))
+	{
+		UE_LOG(LogStats, Error, TEXT("File seems invalid!"));
+		return false;
+	}
+
+	FArchiveLoadCompressedProxy proxy = FArchiveLoadCompressedProxy(compressedData, COMPRESS_ZLIB);
+
+	if (proxy.GetError())
+	{
+		UE_LOG(LogStats, Error, TEXT("The file could not be decompressed! Is it compressed?"));
+		return false;
+	}
+
+	FBufferArchive bufArchive;
+	proxy << bufArchive;
+
+	FMemoryReader memReader = FMemoryReader(bufArchive, true);
+	memReader.Seek(0);
+
+	FBrickGridData toBeLoaded;
+
+	memReader << toBeLoaded;
+
+	SetData(toBeLoaded);
+
+	compressedData.Empty();
+	proxy.FlushCache();
+	memReader.FlushCache();
+
+	bufArchive.Empty();
+	bufArchive.Close();
+
+	return true;
+}
+
 FBoxSphereBounds UBrickGridComponent::CalcBounds(const FTransform & LocalToWorld) const
 {
 	// Return a bounds that fills the world.


### PR DESCRIPTION
This allows you to save and load the brick grid data with ZLIB compression.   
**Saving:**
  + Stores the FBrickGridData inside a buffer archive
  + Uses Unreal's wrappers in order to compress it with ZLIB and save it into a file

**Loading:**
  + Loads the file and stores it's contents inside a buffer archive
  + Uses Unreal's wrappers in order to decompress it with ZLIB
  + The output data is passed to the BrickGrid with **SetData()**